### PR TITLE
 fix missing head

### DIFF
--- a/.github/workflows/mercurial-sync.yml
+++ b/.github/workflows/mercurial-sync.yml
@@ -49,9 +49,14 @@ jobs:
           # This enables incremental conversion by telling hg-fast-export which commits were already converted
           if git show origin/mercurial-sync-meta:hg2git-marks > .git/hg2git-marks 2>/dev/null && \
              git show origin/mercurial-sync-meta:hg2git-state > .git/hg2git-state 2>/dev/null && \
-             git show origin/mercurial-sync-meta:hg2git-mapping > .git/hg2git-mapping 2>/dev/null; then
+             git show origin/mercurial-sync-meta:hg2git-mapping > .git/hg2git-mapping 2>/dev/null && \
+             git show origin/mercurial-sync-meta:hg2git-heads > .git/hg2git-heads 2>/dev/null; then
             # State exists, checkout the branch for incremental update
             git checkout -b mercurial-sync origin/mercurial-sync
+          else
+            # No complete state found, remove existing branch refs to allow fresh conversion
+            git branch -D mercurial-sync 2>/dev/null || true
+            git update-ref -d refs/remotes/origin/mercurial-sync 2>/dev/null || true
           fi
           ../fast-export/hg-fast-export.sh -r ../upstream-hg -M mercurial-sync --force
 
@@ -76,6 +81,7 @@ jobs:
           cp .git/hg2git-marks . 2>/dev/null || true
           cp .git/hg2git-state . 2>/dev/null || true
           cp .git/hg2git-mapping . 2>/dev/null || true
-          git add hg2git-marks hg2git-state hg2git-mapping 2>/dev/null || true
+          cp .git/hg2git-heads . 2>/dev/null || true
+          git add hg2git-marks hg2git-state hg2git-mapping hg2git-heads 2>/dev/null || true
           git commit -m "Update conversion state" || true
           git push origin temp-meta:mercurial-sync-meta --force


### PR DESCRIPTION
Fix mercurial-sync incremental import failure                                                                                      

##  Summary                                                                                                                            

  - Add hg2git-heads file to state preservation and restoration                                                                      
  - Handle incomplete state by removing conflicting branch refs for fresh conversion                                                 
        
                                                                                                                                     
  Summary                                                                                                                            
                                                                                                                                     
  - Add hg2git-heads file to state preservation and restoration                                                                      
  - Handle incomplete state by removing conflicting branch refs for fresh conversion                                                 
                                                                                                                                     
  Problem                                                                                                                            
                                                                                                                                     
  The workflow was failing with:                                                                                                     
  Error: Branch [mercurial-sync] already exists and was not created by hg-fast-export                                                
  fatal: not a valid commit: ae2453ee57d6ab762da4df05a680c75bca3310d1                                                                
                                                                                                                                     
  The hg2git-heads file was missing from the saved state, causing hg-fast-export to not recognize that it had previously created the 
  mercurial-sync branch.                                                                                                             
                                                                                                                                     
  Fix                                                                                                                                
                                                                                                                                     
  1. Save and restore hg2git-heads alongside the other state files                                                                   
  2. When state is incomplete, remove existing branch refs to allow a clean fresh 
  Problem                                                                                                                            
                                                                                                                                     
  The workflow was failing with:                                                                                                     
  Error: Branch [mercurial-sync] already exists and was not created by hg-fast-export                                                
  fatal: not a valid commit: ae2453ee57d6ab762da4df05a680c75bca3310d1                                                                
                                                                                                                                     
  The hg2git-heads file was missing from the saved state, causing hg-fast-export to not recognize that it had previously created the 
  mercurial-sync branch.                                                                                                             
                                                                                                                                     
